### PR TITLE
Use a gender-neutral pronoun when announcing rating

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function postToSlack(checkin) {
       checkin.user.user_name + " is drinking <https://untappd.com/beer/" + checkin.beer.bid + "|" + checkin.beer.beer_name.replace('\'', '’') + "> " +
       "(" + checkin.beer.beer_style.replace('\'', '’') + ", " + checkin.beer.beer_abv + "% ABV) " +
       "by <https://untappd.com/brewery/" + checkin.brewery.brewery_id + "|" + checkin.brewery.brewery_name.replace('\'', '’') + ">.\n" + 
-      "He rated it a " + checkin.rating_score + 
+      "They rated it a " + checkin.rating_score + 
         (checkin.checkin_comment ?
           " and said \"" + checkin.checkin_comment.replace('\'', '’') + "\". " :
           ". ") +


### PR DESCRIPTION
This changes the hard-coded "He" in "He rated it a 4" at https://github.com/nicksergeant/slacktappd/blob/master/index.js#L22

...that seems like the simplest solution to incorrectly saying "he" when a "she" drinks a beer. That is, until Untappd's API  gender to the [/user/info](https://untappd.com/api/docs#user_info) endpoint.
